### PR TITLE
fix: handling int backed enums with zero as backing balue

### DIFF
--- a/src/Traits/EnumFrom.php
+++ b/src/Traits/EnumFrom.php
@@ -20,9 +20,8 @@ trait EnumFrom
         }
 
         if (is_string($value) && self::isIntBacked()) {
-            $tmpValue = intval($value);
-            if (! empty($tmpValue)) {
-                $enum = self::tryFrom($tmpValue);
+            if (is_numeric($value)) {
+                $enum = self::tryFrom(intval($value));
             }
         } else {
             $enum = self::tryFrom($value);


### PR DESCRIPTION
since empty($tmpValue) returns true if ExampleEnum::CASE === 0