### PR TITLE
feat: non breaking strict mode for EnumFrom@wrap

### DIFF
--- a/src/Traits/EnumFrom.php
+++ b/src/Traits/EnumFrom.php
@@ -20,31 +20,31 @@ trait EnumFrom
  * @return ?self The matched enum instance, or null if no match is found and `$strict` is false.
  * @throws \ValueError If `$strict` is true and the value is not a valid enum name or backing value.
  */
-public static function wrap(self|string|int|null $value, bool $strict = false): ?self
-{
-    if ($value instanceof self || is_null($value)) {
-        return $value;
-    }
-
-    $enum = null;
-    if (is_string($value) && self::isIntBacked()) {
-        if(is_numeric($value)){
-            $enum = self::tryFrom(intval($value));
+    public static function wrap(self|string|int|null $value, bool $strict = false): ?self
+    {
+        if ($value instanceof self || is_null($value)) {
+            return $value;
         }
-    } else {
-        $enum = self::tryFrom($value);
-    }
 
-    if ($enum === null && is_string($value)) {
-        $enum = self::tryFromName($value);
-    }
-    
-    if (is_null($enum) and $strict) {
-        throw new ValueError('"'.$value.'" is not a valid backing value for enum "'.self::class.'"');
-    }
+        $enum = null;
+        if (is_string($value) && self::isIntBacked()) {
+            if (is_numeric($value)) {
+                $enum = self::tryFrom(intval($value));
+            }
+        } else {
+            $enum = self::tryFrom($value);
+        }
 
-    return $enum;
-}
+        if ($enum === null && is_string($value)) {
+            $enum = self::tryFromName($value);
+        }
+
+        if (is_null($enum) and $strict) {
+            throw new ValueError('"'.$value.'" is not a valid backing value for enum "'.self::class.'"');
+        }
+
+        return $enum;
+    }
 
     /**
      * Gets the Enum by name, if it exists, for "Pure" enums.

--- a/src/Traits/EnumFrom.php
+++ b/src/Traits/EnumFrom.php
@@ -11,29 +11,40 @@ trait EnumFrom
     use EnumEquality;
 
     /**
-     * Gets the Enum by name, value or another enum.
-     */
-    public static function wrap(self|string|int|null $value): ?self
-    {
-        if ($value instanceof self || is_null($value)) {
-            return $value;
-        }
-
-        $enum = null;
-        if (is_string($value) && self::isIntBacked()) {
-            if(is_numeric($value)){
-                $enum = self::tryFrom(intval($value));
-            }
-        } else {
-            $enum = self::tryFrom($value);
-        }
-
-        if ($enum === null && is_string($value)) {
-            $enum = self::tryFromName($value);
-        }
-
-        return $enum;
+ * Gets the Enum by name, value or another enum.
+ *
+ * @param self|string|int|null $value The value to wrap as the enum. If an instance of the enum is passed it is returned unchanged.
+ *                                  Strings are treated as either backing values (for int-backed enums) or names.
+ * @param bool $strict When true, the method throws a {@see ValueError} if the given value cannot be converted to a valid enum.
+ *                     When false (default), the method returns null on failure.
+ * @return ?self The matched enum instance, or null if no match is found and `$strict` is false.
+ * @throws \ValueError If `$strict` is true and the value is not a valid enum name or backing value.
+ */
+public static function wrap(self|string|int|null $value, bool $strict = false): ?self
+{
+    if ($value instanceof self || is_null($value)) {
+        return $value;
     }
+
+    $enum = null;
+    if (is_string($value) && self::isIntBacked()) {
+        if(is_numeric($value)){
+            $enum = self::tryFrom(intval($value));
+        }
+    } else {
+        $enum = self::tryFrom($value);
+    }
+
+    if ($enum === null && is_string($value)) {
+        $enum = self::tryFromName($value);
+    }
+    
+    if (is_null($enum) and $strict) {
+        throw new ValueError('"'.$value.'" is not a valid backing value for enum "'.self::class.'"');
+    }
+
+    return $enum;
+}
 
     /**
      * Gets the Enum by name, if it exists, for "Pure" enums.

--- a/src/Traits/EnumInvokable.php
+++ b/src/Traits/EnumInvokable.php
@@ -26,7 +26,7 @@ trait EnumInvokable
     {
         foreach (self::cases() as $case) {
             $check1 = strtolower($case->name);
-            $check2 = str_replace('_', '',strtolower($case->name));
+            $check2 = str_replace('_', '', strtolower($case->name));
             if (
                 $check1 === strtolower($enumName)
                 || $check1 === strtolower(self::snake($enumName))

--- a/tests/EnumFromTest.php
+++ b/tests/EnumFromTest.php
@@ -51,7 +51,7 @@ it('throws ValueError for invalid backing value in strict mode', function () {
         ->toThrow(ValueError::class);
 });
 
-it('returns null for invalid backing value when not in strict mode', function() {   
+it('returns null for invalid backing value when not in strict mode', function () {
     expect(StringBackedEnum::wrap('non-existent-value'))
         ->toBeNull();
 });

--- a/tests/EnumFromTest.php
+++ b/tests/EnumFromTest.php
@@ -46,6 +46,16 @@ it('throw ValueError exception with from method', function ($enumClass, $value) 
     'String Backed Enum' => [StringBackedEnum::class, 'M'],
 ]);
 
+it('throws ValueError for invalid backing value in strict mode', function () {
+    expect(fn () => StringBackedEnum::wrap('non-existent-value', true))
+        ->toThrow(ValueError::class);
+});
+
+it('returns null for invalid backing value when not in strict mode', function() {   
+    expect(StringBackedEnum::wrap('non-existent-value'))
+        ->toBeNull();
+});
+
 it('does work with tryFrom method', function ($enumCass, $value, $result) {
     expect($enumCass::tryFrom($value))->toBe($result)->not->toThrow(ValueError::class);
 })->with([


### PR DESCRIPTION
When `strict` is `true`, `Enum::wrap(self|string|int|null $value, bool $strict = false)` now throws a `ValueError` if the value cannot be resolved to an enum instance. Default behavior is unchanged (returns `null`). 