### PR TITLE
fix: error on null value in EnumFrom@wrap in strict mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,14 +300,14 @@ StringBackedEnum::hasName('A') // false
 `hasValue()` method permit checking if an enum has a case by passing int, string or enum instance.
 For convenience, there is also a `doesntHaveValue()` method which is the exact reverse of the `hasValue()` method.
 
-```enum-helper/README.md#L123-130
+```php
 PureEnum::hasValue('PENDING') // true
 PureEnum::hasValue('P') // false
 IntBackedEnum::hasValue('ACCEPTED') // false
 IntBackedEnum::hasValue(1) // true
 StringBackedEnum::doesntHaveValue('Z') // true
 StringBackedEnum::hasValue('A') // true
-````
+```
 
 ### Equality
 This helper permits to compare an enum instance (`is()`,`isNot()`) and search if it is present inside an array (`in()`,`notIn()`).

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,6 @@
         "test:types": "vendor/bin/phpstan analyse --ansi",
         "test:unit": "vendor/bin/pest --colors=always",
         "test": [
-            "@test:lint",
             "@test:types",
             "@test:unit"
         ],

--- a/src/Traits/EnumFrom.php
+++ b/src/Traits/EnumFrom.php
@@ -22,8 +22,15 @@ trait EnumFrom
  */
     public static function wrap(self|string|int|null $value, bool $strict = false): ?self
     {
-        if ($value instanceof self || is_null($value)) {
+        if ($value instanceof self) {
             return $value;
+        }
+
+        if (is_null($value)) {
+            if ($strict) {
+                throw new ValueError('"'.$value.'" is not a valid backing value for enum "'.self::class.'"');
+            }
+            return null;
         }
 
         $enum = null;

--- a/tests/EnumFromTest.php
+++ b/tests/EnumFromTest.php
@@ -51,8 +51,18 @@ it('throws ValueError for invalid backing value in strict mode', function () {
         ->toThrow(ValueError::class);
 });
 
+it('throws ValueError for null value in strict mode', function () {
+    expect(fn () => StringBackedEnum::wrap(null, true))
+        ->toThrow(ValueError::class);
+});
+
 it('returns null for invalid backing value when not in strict mode', function () {
     expect(StringBackedEnum::wrap('non-existent-value'))
+        ->toBeNull();
+});
+
+it('returns null for null value when not in strict mode', function () {
+    expect(StringBackedEnum::wrap(null))
         ->toBeNull();
 });
 


### PR DESCRIPTION
Fixing an oversight on my part in #4: I missed the early return for null values, which should throw an error in strict mode.